### PR TITLE
fix: return `this` from `end()`

### DIFF
--- a/list-stream.js
+++ b/list-stream.js
@@ -78,6 +78,8 @@ ListStream.prototype.end = function (chunk) {
     this._callback(null, this._chunks)
     this._callback = null
   }
+
+  return this
 }
 
 ListStream.prototype.duplicate = function () {


### PR DESCRIPTION
For consistency with Node Duplex implementation, `end()` should likely return `this` - https://nodejs.org/api/stream.html#writableendchunk-encoding-callback.

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473